### PR TITLE
Fix IndexError caused by missing artist information in track export.

### DIFF
--- a/core/yandex.py
+++ b/core/yandex.py
@@ -16,7 +16,11 @@ class YandexMusicExporter:
             with tqdm(total=0, bar_format='{desc}', position=1) as trank_log:
                 for track in tracks:
                     track = track.fetch_track()
-                    artist = track.artists_name()[0]
+                    # Safely handle the case where there are no artists
+                    if track.artists_name():
+                        artist = track.artists_name()[0]
+                    else:
+                        artist = "Unknown Artist"
                     name = track.title
                     result.append(Track(artist, name))
                     pbar.update(1)


### PR DESCRIPTION
This PR resolves an IndexError that occurs when exporting liked tracks if a track has no associated artist name. Previously, the code assumed that all tracks would have artist name, leading to the error when an empty artist list was encountered.

Changes include:

Added a check to ensure track.artists_name() is non-empty before accessing the first element. If no artists are available, the track will be logged and exported with the artist name "Unknown Artist" as a fallback.