### PR TITLE
Fix OAuth authentication and add retry logic for timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,51 @@
 ## Интерфейс программы
 
 ```bash
-python main.py --help                                                         
-usage: main.py [-h] [--yandex YANDEX] [--output OUTPUT] [--youtube YOUTUBE]
+python main.py --help
+usage: main.py [-h] [--yandex YANDEX] [--output OUTPUT] [--youtube YOUTUBE] [--client-secrets CLIENT_SECRETS]
 
 Transfer tracks from Yandex.Music to YouTube Music
 
 options:
-  -h, --help         show this help message and exit
-  --yandex YANDEX    Yandex Music token
-  --output OUTPUT    Output json file
-  --youtube YOUTUBE  Youtube Music credentials file. If file not exists, it will be created.
+  -h, --help            show this help message and exit
+  --yandex YANDEX       Yandex Music token
+  --output OUTPUT       Output json file
+  --youtube YOUTUBE     Youtube Music credentials file. If file not exists, it will be created.
+  --client-secrets CLIENT_SECRETS
+                        Path to Google OAuth client secrets JSON file (required for first-time setup)
 ```
 
 ## Использование
 
-1. [Получить Yandex Music token](https://yandex-music.readthedocs.io/en/main/token.html). Легче всего это сделать с помошью приложения.
-2. Установить зависимости и запустить программу:
+### 1. Получить Yandex Music токен
+
+[Получить Yandex Music token](https://yandex-music.readthedocs.io/en/main/token.html). Легче всего это сделать с помошью приложения.
+
+### 2. Получить Google OAuth credentials
+
+1. Перейти в [Google Cloud Console](https://console.cloud.google.com/)
+2. Создать новый проект или выбрать существующий
+3. Перейти в **APIs & Services** → **Library**
+4. Найти **YouTube Data API v3** и нажать **Enable**
+5. Перейти в **APIs & Services** → **OAuth consent screen**
+   - Выбрать **External** и создать
+   - Заполнить обязательные поля (название приложения, email)
+   - В разделе **Test users** добавить email вашего Google аккаунта
+6. Перейти в **APIs & Services** → **Credentials**
+7. Нажать **Create Credentials** → **OAuth client ID**
+8. Выбрать тип приложения: **TVs and Limited Input devices**
+9. Скачать JSON файл с credentials
+
+### 3. Запустить программу
+
 ```bash
 pip install -r requirements.txt
-python main.py --yandex <Yandex Music token>
+python main.py --yandex <Yandex Music token> --client-secrets <path to Google OAuth JSON>
 ```
-3. При запуске программы перейти по предложенной ссылке для авторизации в YouTube Music, разрешить доступ к аккаунту и нажать `Enter` для продолжения.
+
+### 4. Авторизация в YouTube Music
+
+При запуске программы перейти по предложенной ссылке, ввести код из терминала и разрешить доступ к аккаунту.
 4. Дождаться завершения работы программы. Программа также экспортирует музыку Json в файл:
 
 ```json

--- a/README_EN.md
+++ b/README_EN.md
@@ -7,29 +7,51 @@ Transfer liked tracks from Yandex.Music to YouTube Music.
 ## Program Interface
 
 ```bash
-python main.py --help                                                         
-usage: main.py [-h] [--yandex YANDEX] [--output OUTPUT] [--youtube YOUTUBE]
+python main.py --help
+usage: main.py [-h] [--yandex YANDEX] [--output OUTPUT] [--youtube YOUTUBE] [--client-secrets CLIENT_SECRETS]
 
 Transfer tracks from Yandex.Music to YouTube Music
 
 options:
-  -h, --help         show this help message and exit
-  --yandex YANDEX    Yandex Music token
-  --output OUTPUT    Output json file
-  --youtube YOUTUBE  Youtube Music credentials file. If file not exists, it will be created.
+  -h, --help            show this help message and exit
+  --yandex YANDEX       Yandex Music token
+  --output OUTPUT       Output json file
+  --youtube YOUTUBE     Youtube Music credentials file. If file not exists, it will be created.
+  --client-secrets CLIENT_SECRETS
+                        Path to Google OAuth client secrets JSON file (required for first-time setup)
 ```
 
 ## Usage
 
-1. [Get Yandex Music token](https://yandex-music.readthedocs.io/en/main/token.html). It is easiest to do this with the application.
-2. Install dependencies and run the program:
+### 1. Get Yandex Music token
+
+[Get Yandex Music token](https://yandex-music.readthedocs.io/en/main/token.html). It is easiest to do this with the application.
+
+### 2. Get Google OAuth credentials
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Go to **APIs & Services** → **Library**
+4. Find **YouTube Data API v3** and click **Enable**
+5. Go to **APIs & Services** → **OAuth consent screen**
+   - Select **External** and create
+   - Fill in required fields (app name, email)
+   - In the **Test users** section, add your Google account email
+6. Go to **APIs & Services** → **Credentials**
+7. Click **Create Credentials** → **OAuth client ID**
+8. Select application type: **TVs and Limited Input devices**
+9. Download the JSON credentials file
+
+### 3. Run the program
 
 ```bash
 pip install -r requirements.txt
-python main.py --yandex <Yandex Music token>
+python main.py --yandex <Yandex Music token> --client-secrets <path to Google OAuth JSON>
 ```
 
-3. When starting the program, follow the provided link to authorize in YouTube Music, allow access to the account, and press `Enter` to continue.
+### 4. YouTube Music authorization
+
+When starting the program, follow the provided link, enter the code from the terminal, and allow access to the account.
 4. Wait for the program to finish. The program will also export music data to a JSON file:
 
 ```json

--- a/main.py
+++ b/main.py
@@ -16,8 +16,12 @@ def parse_args() -> argparse.Namespace:
         '--output', type=str, default='tracks.json', help='Output json file'
     )
     parser.add_argument(
-        '--youtube', type=str, default='youtube.json', 
+        '--youtube', type=str, default='youtube.json',
         help='Youtube Music credentials file. If file not exists, it will be created.'
+    )
+    parser.add_argument(
+        '--client-secrets', type=str,
+        help='Path to Google OAuth client secrets JSON file (required for first-time setup)'
     )
     return parser.parse_args()
 
@@ -67,7 +71,7 @@ def move_tracks(
 def main() -> None:
     args = parse_args()
     importer = YandexMusicExporter(args.yandex)
-    exporter = YoutubeImoirter(args.youtube)
+    exporter = YoutubeImoirter(args.youtube, args.client_secrets)
     move_tracks(importer, exporter, args.output)
 
 


### PR DESCRIPTION
- Update YouTube OAuth to use client_id and client_secret (required by ytmusicapi 1.9+)
- Add --client-secrets argument for Google OAuth credentials JSON
- Add retry logic with exponential backoff for Yandex Music API timeouts
- Update README with Google OAuth setup instructions